### PR TITLE
Ex10si0n/continue stmt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,7 @@
 vcs/*.smt2
 
 Strata.code-workspace
+
+conformance_testing/failures/*
+package.json
+package-lock.json

--- a/Strata/Languages/TypeScript/TS_to_Strata.lean
+++ b/Strata/Languages/TypeScript/TS_to_Strata.lean
@@ -64,7 +64,7 @@ def TS_type_to_HMonoTy (ty: String) : Heap.HMonoTy :=
   | "TS_TSNumberKeyword" => Heap.HMonoTy.int
   | "TS_TSBooleanKeyword" => Heap.HMonoTy.bool
   | "TS_TSStringKeyword" => Heap.HMonoTy.string
-  | "TS_TSArrayType" => Heap.HMonoTy.addr
+  -- | "TS_TSArrayType" => Heap.HMonoTy.addr
   | _ => panic! s!"Unsupported type: {ty}"
 
 def Option_TS_TSTypeKeyword_to_str (i: Option TS_TSTypeKeyword) : String :=
@@ -73,7 +73,7 @@ def Option_TS_TSTypeKeyword_to_str (i: Option TS_TSTypeKeyword) : String :=
     | .TS_TSNumberKeyword _ => "TS_TSNumberKeyword"
     | .TS_TSBooleanKeyword _ => "TS_TSBooleanKeyword"
     | .TS_TSStringKeyword _ => "TS_TSStringKeyword"
-    | .TS_TSArrayType _ => "TS_TSArrayType"
+    -- | .TS_TSArrayType _ => "TS_TSArrayType"
   | .none => panic! "Unimplemented"
 
 -- Helper to extract type from optional type annotation
@@ -86,7 +86,7 @@ def extract_type_from_annotation (ann: Option TS_TSTypeAnnotation) : String :=
 partial def infer_type_from_expr (expr: TS_Expression) : Heap.HMonoTy :=
   match expr with
   | .TS_ObjectExpression _ => Heap.HMonoTy.addr  -- Objects are addresses
-  | .TS_ArrayExpression _ => Heap.HMonoTy.addr   -- Arrays are addresses
+  -- | .TS_ArrayExpression _ => Heap.HMonoTy.addr   -- Arrays are addresses
   | .TS_NumericLiteral _ => Heap.HMonoTy.int
   | .TS_BooleanLiteral _ => Heap.HMonoTy.bool
   | .TS_BinaryExpression e =>
@@ -155,12 +155,12 @@ partial def translate_expr (e: TS_Expression) : Heap.HExpr :=
   | .TS_NullLiteral _ =>
     Heap.HExpr.null
 
-  | .TS_ArrayExpression arr =>
-    -- Translate [value1, value2, value3] to heap allocation with numeric indices
-    let fields := arr.elements.toList.mapIdx (fun idx elem =>
-      (idx, translate_expr elem))
-    -- Arrays store elements at numeric indices: 0->value1, 1->value2, etc.
-    Heap.HExpr.allocSimple fields
+  -- | .TS_ArrayExpression arr =>
+    -- -- Translate [value1, value2, value3] to heap allocation with numeric indices
+    -- let fields := arr.elements.toList.mapIdx (fun idx elem =>
+      -- (idx, translate_expr elem))
+    -- -- Arrays store elements at numeric indices: 0->value1, 1->value2, etc.
+    -- Heap.HExpr.allocSimple fields
 
   | .TS_MemberExpression e =>
     -- Translate obj[index] to heap dereference

--- a/Strata/Languages/TypeScript/TS_to_Strata.lean
+++ b/Strata/Languages/TypeScript/TS_to_Strata.lean
@@ -32,11 +32,20 @@ instance : Inhabited TranslationContext where
 instance : Inhabited (TranslationContext × List TSStrataStatement) where
   default := (TranslationContext.empty, [])
 
+-- ControlTargets tells where continue/break jumps to
+structure ControlTargets where
+  continueLabel? : Option String := none
+  -- TODO: break control target defined but not yet implemented
+  breakLabel? : Option String := none
+deriving Inhabited
+
+
 def TS_type_to_HMonoTy (ty: String) : Heap.HMonoTy :=
   match ty with
   | "TS_TSNumberKeyword" => Heap.HMonoTy.int
   | "TS_TSBooleanKeyword" => Heap.HMonoTy.bool
   | "TS_TSStringKeyword" => Heap.HMonoTy.string
+  | "TS_TSArrayType" => Heap.HMonoTy.addr
   | _ => panic! s!"Unsupported type: {ty}"
 
 def Option_TS_TSTypeKeyword_to_str (i: Option TS_TSTypeKeyword) : String :=
@@ -45,6 +54,7 @@ def Option_TS_TSTypeKeyword_to_str (i: Option TS_TSTypeKeyword) : String :=
     | .TS_TSNumberKeyword _ => "TS_TSNumberKeyword"
     | .TS_TSBooleanKeyword _ => "TS_TSBooleanKeyword"
     | .TS_TSStringKeyword _ => "TS_TSStringKeyword"
+    | .TS_TSArrayType _ => "TS_TSArrayType"
   | .none => panic! "Unimplemented"
 
 -- Helper to extract type from optional type annotation
@@ -57,6 +67,7 @@ def extract_type_from_annotation (ann: Option TS_TSTypeAnnotation) : String :=
 partial def infer_type_from_expr (expr: TS_Expression) : Heap.HMonoTy :=
   match expr with
   | .TS_ObjectExpression _ => Heap.HMonoTy.addr  -- Objects are addresses
+  | .TS_ArrayExpression _ => Heap.HMonoTy.addr   -- Arrays are addresses
   | .TS_NumericLiteral _ => Heap.HMonoTy.int
   | .TS_BooleanLiteral _ => Heap.HMonoTy.bool
   | .TS_BinaryExpression e =>
@@ -124,6 +135,13 @@ partial def translate_expr (e: TS_Expression) : Heap.HExpr :=
   | .TS_NullLiteral _ =>
     Heap.HExpr.null
 
+  | .TS_ArrayExpression arr =>
+    -- Translate [value1, value2, value3] to heap allocation with numeric indices
+    let fields := arr.elements.toList.mapIdx (fun idx elem =>
+      (idx, translate_expr elem))
+    -- Arrays store elements at numeric indices: 0->value1, 1->value2, etc.
+    Heap.HExpr.allocSimple fields
+
   | .TS_MemberExpression e =>
     -- Translate obj[index] to heap dereference
     let objExpr := translate_expr e.object
@@ -160,154 +178,154 @@ partial def translate_expr (e: TS_Expression) : Heap.HExpr :=
 
   | _ => panic! s!"Unimplemented expression: {repr e}"
 
+partial def translate_statement_core
+  (s: TS_Statement)
+  (ctx : TranslationContext)
+  (ct: ControlTargets := {}) : TranslationContext × List TSStrataStatement :=
+  match s with
+    | .TS_FunctionDeclaration funcDecl =>
+        -- Translate function definition
+        dbg_trace s!"[DEBUG] Translating TypeScript function definition: {funcDecl.id.name}"
+        dbg_trace s!"[DEBUG] Function parameters: {funcDecl.params.toList.map (·.name)}"
+        dbg_trace s!"[DEBUG] Function body has statements"
+
+        let funcBody := match funcDecl.body with
+          | .TS_BlockStatement blockStmt =>
+            (blockStmt.body.toList.map (fun stmt => translate_statement_core stmt ctx ct |>.snd)).flatten
+          | _ => panic! s!"Expected block statement as function body, got: {repr funcDecl.body}"
+
+        dbg_trace s!"[DEBUG] Translated function body to {funcBody.length} Strata statements"
+
+        let strataFunc : CallHeapStrataFunction := {
+          name := funcDecl.id.name,
+          params := funcDecl.params.toList.map (·.name),
+          body := funcBody,
+          returnType := none  -- We'll infer this later if needed
+        }
+        let newCtx := ctx.addFunction strataFunc
+        dbg_trace s!"[DEBUG] Added TypeScript function '{funcDecl.id.name}' to context"
+        -- Function definitions don't generate statements themselves, just update context
+        (newCtx, [])
+
+      | .TS_ReturnStatement ret =>
+        -- Handle return statements
+        match ret.argument with
+        | some expr =>
+          let returnExpr := translate_expr expr
+          dbg_trace s!"[DEBUG] setting return expr {repr returnExpr}!"
+          -- For now, store return value in a special variable
+          -- TODO: Implement proper return handling
+          (ctx, [.cmd (.set "return_value" returnExpr)])
+        | none =>
+          -- Void return
+          (ctx, [.cmd (.set "return_value" (Heap.HExpr.int 1))])
+
+      | .TS_VariableDeclaration decl =>
+        match decl.declarations[0]? with
+        | .none => panic! "VariableDeclarations should have at least one declaration"
+        | .some d =>
+          -- Check if this is a function call assignment
+          match d.init with
+          | .TS_CallExpression call =>
+            -- Handle function call assignment: let x = func(args)
+            dbg_trace s!"[DEBUG] Translating TypeScript function call assignment: {d.id.name} = {call.callee.name}(...)"
+            let args := call.arguments.toList.map translate_expr
+            dbg_trace s!"[DEBUG] Function call has {args.length} arguments"
+            let lhs := [d.id.name]  -- Left-hand side variables to store result
+            (ctx, [.cmd (.directCall lhs call.callee.name args)])
+          | _ =>
+            -- Handle simple variable declaration: let x = value
+            let value := translate_expr d.init
+            let ty := get_var_type d.id.typeAnnotation d.init
+            (ctx, [.cmd (.init d.id.name ty value)])
+
+      | .TS_ExpressionStatement expr =>
+        match expr.expression with
+        | .TS_CallExpression call =>
+          -- Handle standalone function call
+          dbg_trace s!"[DEBUG] Translating TypeScript standalone function call: {call.callee.name}(...)"
+          let args := call.arguments.toList.map translate_expr
+          dbg_trace s!"[DEBUG] Function call has {args.length} arguments"
+          let lhs := []  -- No left-hand side for standalone calls
+          (ctx, [.cmd (.directCall lhs call.callee.name args)])
+        | .TS_AssignmentExpression assgn =>
+          assert! assgn.operator == "="
+          match assgn.left with
+          | .TS_Identifier id =>
+            -- Handle identifier assignment: x = value
+            let value := translate_expr assgn.right
+            dbg_trace s!"[DEBUG] Assignment: {id.name} = {repr value}"
+            (ctx, [.cmd (.set id.name value)])
+          | .TS_MemberExpression member =>
+            -- Handle field assignment: obj[field] = value
+            let objExpr := translate_expr member.object
+            let valueExpr := translate_expr assgn.right
+
+            -- Handle both static and dynamic field assignment
+            match member.property with
+            | .TS_NumericLiteral numLit =>
+              -- Static field assignment: obj[5] = value
+              let fieldIndex := Float.floor numLit.value |>.toUInt64.toNat
+              let assignExpr := Heap.HExpr.assign objExpr fieldIndex valueExpr
+              (ctx, [.cmd (.set "temp_assign_result" assignExpr)])
+            | .TS_IdExpression id =>
+              -- Dynamic field assignment: obj[variable] = value
+              let fieldExpr := translate_expr (.TS_IdExpression id)
+              let assignExpr := Heap.HExpr.app (Heap.HExpr.app (Heap.HExpr.app (Heap.HExpr.deferredOp "DynamicFieldAssign" none) objExpr) fieldExpr) valueExpr
+              (ctx, [.cmd (.set "temp_assign_result" assignExpr)])
+            | _ =>
+              -- Other dynamic field assignment: obj[expr] = value
+              let fieldExpr := translate_expr member.property
+              let assignExpr := Heap.HExpr.app (Heap.HExpr.app (Heap.HExpr.app (Heap.HExpr.deferredOp "DynamicFieldAssign" none) objExpr) fieldExpr) valueExpr
+              (ctx, [.cmd (.set "temp_assign_result" assignExpr)])
+          --| _ => panic! s!"Unsupported assignment target: {repr assgn.left}"
+        | _ =>
+          -- Other expression statements - ignore for now
+          (ctx, [])
+
+      | .TS_BlockStatement block =>
+        -- Handle block statement: { stmt1; stmt2; ... }
+        let (finalCtx, allStmts) := block.body.toList.foldl (fun (accCtx, accStmts) stmt =>
+          let (newCtx, stmts) := translate_statement_core stmt accCtx ct
+          (newCtx, accStmts ++ stmts)) (ctx, [])
+        (finalCtx, allStmts)
+
+      | .TS_IfStatement ifStmt =>
+        -- Handle if statement: if test then consequent else alternate
+        let testExpr := translate_expr ifStmt.test
+        let (thenCtx, thenStmts) := translate_statement_core ifStmt.consequent ctx ct
+        let (elseCtx, elseStmts) := match ifStmt.alternate with
+          | some altStmt => translate_statement_core altStmt ctx ct
+          | none => (ctx, [])
+        let thenBlock : Imperative.Block TSStrataExpression TSStrataCommand := { ss := thenStmts }
+        let elseBlock : Imperative.Block TSStrataExpression TSStrataCommand := { ss := elseStmts }
+        -- For now, we'll use the then context (could be more sophisticated)
+        (thenCtx, [.ite testExpr thenBlock elseBlock])
+
+      | .TS_WhileStatement whileStmt =>
+        dbg_trace s!"[DEBUG] Translating while statement at loc {whileStmt.start_loc}-{whileStmt.end_loc}"
+        dbg_trace s!"[DEBUG] While test: {repr whileStmt.test}"
+        dbg_trace s!"[DEBUG] While body: {repr whileStmt.body}"
+        let testExpr := translate_expr whileStmt.test
+        let (bodyCtx, bodyStmts) := translate_statement_core whileStmt.body ctx ct
+        let bodyBlock : Imperative.Block TSStrataExpression TSStrataCommand := { ss := bodyStmts }
+        (bodyCtx, [.loop testExpr none none bodyBlock])
+
+      | .TS_ContinueStatement cont =>
+        let tgt :=
+          match ct.continueLabel? with
+          | some lab => lab
+          | none     =>
+              dbg_trace "[WARN] `continue` encountered outside of a loop; emitting goto to __unbound_continue";
+              "__unbound_continue"
+        (ctx, [ .goto tgt ])
+
+      | _ => panic! s!"Unimplemented statement: {repr s}"
+
 -- Translate TypeScript statements to TypeScript-Strata statements
 partial def translate_statement (s: TS_Statement) (ctx : TranslationContext) : TranslationContext × List TSStrataStatement :=
-  match s with
-  | .TS_FunctionDeclaration funcDecl =>
-    -- Translate function definition
-    dbg_trace s!"[DEBUG] Translating TypeScript function definition: {funcDecl.id.name}"
-    dbg_trace s!"[DEBUG] Function parameters: {funcDecl.params.toList.map (·.name)}"
-    dbg_trace s!"[DEBUG] Function body has statements"
+  translate_statement_core s ctx {}
 
-    let funcBody := match funcDecl.body with
-      | .TS_BlockStatement blockStmt =>
-        (blockStmt.body.toList.map (fun stmt => translate_statement stmt ctx |>.snd)).flatten
-      | _ => panic! s!"Expected block statement as function body, got: {repr funcDecl.body}"
-
-    dbg_trace s!"[DEBUG] Translated function body to {funcBody.length} Strata statements"
-
-    let strataFunc : CallHeapStrataFunction := {
-      name := funcDecl.id.name,
-      params := funcDecl.params.toList.map (·.name),
-      body := funcBody,
-      returnType := none  -- We'll infer this later if needed
-    }
-    let newCtx := ctx.addFunction strataFunc
-    dbg_trace s!"[DEBUG] Added TypeScript function '{funcDecl.id.name}' to context"
-    -- Function definitions don't generate statements themselves, just update context
-    (newCtx, [])
-
-  | .TS_ReturnStatement ret =>
-    -- Handle return statements
-    match ret.argument with
-    | some expr =>
-      let returnExpr := translate_expr expr
-      dbg_trace s!"[DEBUG] setting return expr {repr returnExpr}!"
-      -- For now, store return value in a special variable
-      -- TODO: Implement proper return handling
-      (ctx, [.cmd (.set "return_value" returnExpr)])
-    | none =>
-      -- Void return
-      (ctx, [.cmd (.set "return_value" (Heap.HExpr.int 1))])
-
-  | .TS_VariableDeclaration decl =>
-    match decl.declarations[0]? with
-    | .none => panic! "VariableDeclarations should have at least one declaration"
-    | .some d =>
-      -- Check if this is a function call assignment
-      match d.init with
-      | .TS_CallExpression call =>
-        -- Handle function call assignment: let x = func(args)
-        dbg_trace s!"[DEBUG] Translating TypeScript function call assignment: {d.id.name} = {call.callee.name}(...)"
-        let args := call.arguments.toList.map translate_expr
-        dbg_trace s!"[DEBUG] Function call has {args.length} arguments"
-        let lhs := [d.id.name]  -- Left-hand side variables to store result
-        (ctx, [.cmd (.directCall lhs call.callee.name args)])
-      | _ =>
-        -- Handle simple variable declaration: let x = value
-        let value := translate_expr d.init
-        let ty := get_var_type d.id.typeAnnotation d.init
-        (ctx, [.cmd (.init d.id.name ty value)])
-
-  | .TS_ExpressionStatement expr =>
-    match expr.expression with
-    | .TS_CallExpression call =>
-      -- Handle standalone function call
-      dbg_trace s!"[DEBUG] Translating TypeScript standalone function call: {call.callee.name}(...)"
-      let args := call.arguments.toList.map translate_expr
-      dbg_trace s!"[DEBUG] Function call has {args.length} arguments"
-      let lhs := []  -- No left-hand side for standalone calls
-      (ctx, [.cmd (.directCall lhs call.callee.name args)])
-    | .TS_AssignmentExpression assgn =>
-      assert! assgn.operator == "="
-      match assgn.left with
-      | .TS_Identifier id =>
-        -- Handle identifier assignment: x = value
-        let value := translate_expr assgn.right
-        dbg_trace s!"[DEBUG] Assignment: {id.name} = {repr value}"
-        (ctx, [.cmd (.set id.name value)])
-      | .TS_MemberExpression member =>
-        -- Handle field assignment: obj[field] = value
-        let objExpr := translate_expr member.object
-        let valueExpr := translate_expr assgn.right
-
-        -- Handle both static and dynamic field assignment
-        match member.property with
-        | .TS_NumericLiteral numLit =>
-          -- Static field assignment: obj[5] = value
-          let fieldIndex := Float.floor numLit.value |>.toUInt64.toNat
-          let assignExpr := Heap.HExpr.assign objExpr fieldIndex valueExpr
-          (ctx, [.cmd (.set "temp_assign_result" assignExpr)])
-        | .TS_IdExpression id =>
-          -- Dynamic field assignment: obj[variable] = value
-          let fieldExpr := translate_expr (.TS_IdExpression id)
-          let assignExpr := Heap.HExpr.app (Heap.HExpr.app (Heap.HExpr.app (Heap.HExpr.deferredOp "DynamicFieldAssign" none) objExpr) fieldExpr) valueExpr
-          (ctx, [.cmd (.set "temp_assign_result" assignExpr)])
-        | _ =>
-          -- Other dynamic field assignment: obj[expr] = value
-          let fieldExpr := translate_expr member.property
-          let assignExpr := Heap.HExpr.app (Heap.HExpr.app (Heap.HExpr.app (Heap.HExpr.deferredOp "DynamicFieldAssign" none) objExpr) fieldExpr) valueExpr
-          (ctx, [.cmd (.set "temp_assign_result" assignExpr)])
-      --| _ => panic! s!"Unsupported assignment target: {repr assgn.left}"
-    | _ =>
-      -- Other expression statements - ignore for now
-      (ctx, [])
-
-  | .TS_BlockStatement block =>
-    -- Handle block statement: { stmt1; stmt2; ... }
-    let (finalCtx, allStmts) := block.body.toList.foldl (fun (accCtx, accStmts) stmt =>
-      let (newCtx, stmts) := translate_statement stmt accCtx
-      (newCtx, accStmts ++ stmts)) (ctx, [])
-    (finalCtx, allStmts)
-
-  | .TS_IfStatement ifStmt =>
-    -- Handle if statement: if test then consequent else alternate
-    let testExpr := translate_expr ifStmt.test
-    let (thenCtx, thenStmts) := translate_statement ifStmt.consequent ctx
-    let (elseCtx, elseStmts) := match ifStmt.alternate with
-      | some altStmt => translate_statement altStmt ctx
-      | none => (ctx, [])
-    let thenBlock : Imperative.Block TSStrataExpression TSStrataCommand := { ss := thenStmts }
-    let elseBlock : Imperative.Block TSStrataExpression TSStrataCommand := { ss := elseStmts }
-    -- For now, we'll use the then context (could be more sophisticated)
-    (thenCtx, [.ite testExpr thenBlock elseBlock])
-
-  | .TS_ForStatement forStmt =>
-    -- init phase
-    let (_, initStmts) := translate_statement (.TS_VariableDeclaration forStmt.init) ctx
-    -- guard (test)
-    let guard := translate_expr forStmt.test
-    -- body (first translate loop body)
-    let (ctx1, bodyStmts) := translate_statement forStmt.body ctx
-    -- update (translate expression into statements following ExpressionStatement style)
-    let (_, updateStmts) :=
-      translate_statement (.TS_ExpressionStatement { expression := .TS_AssignmentExpression forStmt.update, start_loc := forStmt.start_loc, end_loc := forStmt.end_loc, loc:= forStmt.loc, type := "TS_AssignmentExpression" }) ctx1
-    -- assemble loop body (body + update)
-    let loopBody : Imperative.Block TSStrataExpression TSStrataCommand :=
-      { ss := bodyStmts ++ updateStmts }
-
-    -- output: init statements first, then a loop statement
-    (ctx1, initStmts ++ [.loop guard none none loopBody])
-
-  | .TS_WhileStatement whileStmt =>
-    dbg_trace s!"[DEBUG] Translating while statement at loc {whileStmt.start_loc}-{whileStmt.end_loc}"
-    dbg_trace s!"[DEBUG] While test: {repr whileStmt.test}"
-    dbg_trace s!"[DEBUG] While body: {repr whileStmt.body}"
-    let testExpr := translate_expr whileStmt.test
-    let (bodyCtx, bodyStmts) := translate_statement whileStmt.body ctx
-    let bodyBlock : Imperative.Block TSStrataExpression TSStrataCommand := { ss := bodyStmts }
-    (bodyCtx, [.loop testExpr none none bodyBlock])
-  | _ => panic! s!"Unimplemented statement: {repr s}"
 
 -- Translate list of TypeScript statements with context
 def translate_program (statements: List TS_Statement) : TranslationContext × List TSStrataStatement :=

--- a/Strata/Languages/TypeScript/js_ast.lean
+++ b/Strata/Languages/TypeScript/js_ast.lean
@@ -45,13 +45,13 @@ mutual
     | TS_TSNumberKeyword : TS_TSNumberKeyword → TS_TSTypeKeyword
     | TS_TSBooleanKeyword : TS_TSBooleanKeyword → TS_TSTypeKeyword
     | TS_TSStringKeyword : TS_TSStringKeyword → TS_TSTypeKeyword
-    | TS_TSArrayType : TS_TSArrayType → TS_TSTypeKeyword
+    -- | TS_TSArrayType : TS_TSArrayType → TS_TSTypeKeyword
   deriving Repr, Lean.FromJson, Lean.ToJson
 
   -- TODO: Array not as a type?
-  structure TS_TSArrayType extends BaseNode where
-    elementType : TS_TSTypeKeyword
-  deriving Repr, Lean.FromJson, Lean.ToJson
+  -- structure TS_TSArrayType extends BaseNode where
+    -- elementType : TS_TSTypeKeyword
+  -- deriving Repr, Lean.FromJson, Lean.ToJson
 end
 
 structure TS_TSTypeAnnotation extends BaseNode where
@@ -144,9 +144,9 @@ mutual
     properties: Array TS_ObjectProperty
   deriving Repr, Lean.FromJson, Lean.ToJson
 
-  structure TS_ArrayExpression extends BaseNode where
-    elements : Array TS_Expression
-  deriving Repr, Lean.FromJson, Lean.ToJson
+  -- structure TS_ArrayExpression extends BaseNode where
+    -- elements : Array TS_Expression
+  -- deriving Repr, Lean.FromJson, Lean.ToJson
 
   structure TS_CallExpression extends BaseNode where
     callee : TS_Identifier
@@ -165,7 +165,7 @@ mutual
     | TS_IdExpression : TS_Identifier → TS_Expression
     | TS_UnaryExpression: TS_UnaryExpression → TS_Expression
     | TS_ObjectExpression: TS_ObjectExpression → TS_Expression
-    | TS_ArrayExpression: TS_ArrayExpression → TS_Expression
+    -- | TS_ArrayExpression: TS_ArrayExpression → TS_Expression
     | TS_MemberExpression: TS_MemberExpression → TS_Expression
     | TS_CallExpression: TS_CallExpression → TS_Expression
   deriving Repr, Lean.FromJson, Lean.ToJson

--- a/Strata/Languages/TypeScript/js_ast.lean
+++ b/Strata/Languages/TypeScript/js_ast.lean
@@ -40,11 +40,19 @@ deriving Repr, Lean.FromJson, Lean.ToJson
 structure TS_TSStringKeyword extends BaseNode where
 deriving Repr, Lean.FromJson, Lean.ToJson
 
-inductive TS_TSTypeKeyword where
-  | TS_TSNumberKeyword : TS_TSNumberKeyword → TS_TSTypeKeyword
-  | TS_TSBooleanKeyword : TS_TSBooleanKeyword → TS_TSTypeKeyword
-  | TS_TSStringKeyword : TS_TSStringKeyword → TS_TSTypeKeyword
-deriving Repr, Lean.FromJson, Lean.ToJson
+mutual
+  inductive TS_TSTypeKeyword where
+    | TS_TSNumberKeyword : TS_TSNumberKeyword → TS_TSTypeKeyword
+    | TS_TSBooleanKeyword : TS_TSBooleanKeyword → TS_TSTypeKeyword
+    | TS_TSStringKeyword : TS_TSStringKeyword → TS_TSTypeKeyword
+    | TS_TSArrayType : TS_TSArrayType → TS_TSTypeKeyword
+  deriving Repr, Lean.FromJson, Lean.ToJson
+
+  -- TODO: Array not as a type?
+  structure TS_TSArrayType extends BaseNode where
+    elementType : TS_TSTypeKeyword
+  deriving Repr, Lean.FromJson, Lean.ToJson
+end
 
 structure TS_TSTypeAnnotation extends BaseNode where
   typeAnnotation : Option TS_TSTypeKeyword
@@ -136,6 +144,10 @@ mutual
     properties: Array TS_ObjectProperty
   deriving Repr, Lean.FromJson, Lean.ToJson
 
+  structure TS_ArrayExpression extends BaseNode where
+    elements : Array TS_Expression
+  deriving Repr, Lean.FromJson, Lean.ToJson
+
   structure TS_CallExpression extends BaseNode where
     callee : TS_Identifier
     arguments : Array TS_Expression
@@ -153,6 +165,7 @@ mutual
     | TS_IdExpression : TS_Identifier → TS_Expression
     | TS_UnaryExpression: TS_UnaryExpression → TS_Expression
     | TS_ObjectExpression: TS_ObjectExpression → TS_Expression
+    | TS_ArrayExpression: TS_ArrayExpression → TS_Expression
     | TS_MemberExpression: TS_MemberExpression → TS_Expression
     | TS_CallExpression: TS_CallExpression → TS_Expression
   deriving Repr, Lean.FromJson, Lean.ToJson
@@ -208,12 +221,8 @@ mutual
     body: TS_Statement
   deriving Repr, Lean.FromJson, Lean.ToJson
 
-  /- TODO: Add support for for(let a=0, b=0;a!=0 and b!=0;a++,b++) -/
-  structure TS_ForStatement extends BaseNode where
-    init: TS_VariableDeclaration
-    test: TS_Expression
-    update: TS_AssignmentExpression
-    body: TS_Statement
+  structure TS_ContinueStatement extends BaseNode where
+    label: Option TS_Identifier
   deriving Repr, Lean.FromJson, Lean.ToJson
 
   inductive TS_Statement where
@@ -224,8 +233,8 @@ mutual
     | TS_ThrowStatement : TS_ThrowStatement → TS_Statement
     | TS_ReturnStatement : TS_ReturnStatement → TS_Statement
     | TS_FunctionDeclaration : TS_FunctionDeclaration → TS_Statement
-    | TS_ForStatement : TS_ForStatement → TS_Statement
     | TS_WhileStatement: TS_WhileStatement -> TS_Statement
+    | TS_ContinueStatement: TS_ContinueStatement -> TS_Statement
   deriving Repr, Lean.FromJson, Lean.ToJson
 end
 

--- a/StrataTest/Languages/TypeScript/test_continue.ts
+++ b/StrataTest/Languages/TypeScript/test_continue.ts
@@ -1,6 +1,10 @@
 // Continue for while loop
 let i = 0;
+let j = 0;
 while (i < 10) {
     i = i + 1;
-    continue;
+    if (i % 2 < 1) {
+        continue;
+    }
+    j = j + 1;
 }

--- a/StrataTest/Languages/TypeScript/test_continue.ts
+++ b/StrataTest/Languages/TypeScript/test_continue.ts
@@ -1,0 +1,6 @@
+// Continue for while loop
+let i = 0;
+while (i < 10) {
+    i = i + 1;
+    continue;
+}

--- a/conformance_testing/babel_to_lean.py
+++ b/conformance_testing/babel_to_lean.py
@@ -249,6 +249,14 @@ def parse_while_statement(j):
     }
     add_missing_node_info(j, target_j)
     return target_j
+
+def parse_continue_statement(j):
+    label = j.get("label")
+    target_j = {
+        "label": None if label is None else parse_identifier(label)
+    }
+    add_missing_node_info(j, target_j)
+    return target_j
     
 def parse_for_statement(j):
     target_body = parse_statement(j['body'])
@@ -282,7 +290,8 @@ def parse_statement(j):
         # case "WithStatement":
         # case "LabeledStatement":
         # case "BreakStatement":
-        # case "ContinueStatement":
+        case "ContinueStatement":
+            return {"TS_ContinueStatement": parse_continue_statement(j)}
         # case "SwitchStatement":
         # case "TryStatement":
         case "WhileStatement":

--- a/conformance_testing/failures/Languages/TypeScript/test_while.ts
+++ b/conformance_testing/failures/Languages/TypeScript/test_while.ts
@@ -1,4 +1,0 @@
-let i:number = 0;
-while (i < 1) {
-    i = 3;
-}

--- a/conformance_testing/failures/Languages/TypeScript/test_while.ts
+++ b/conformance_testing/failures/Languages/TypeScript/test_while.ts
@@ -1,4 +1,4 @@
-let i: number = 0;
-while (i < 5) {
-    i = i + 1;
+let i:number = 0;
+while (i < 1) {
+    i = 3;
 }


### PR DESCRIPTION
File changed:

1. `TS_to_Strata.lean` 
2. `js_ast.lean`
    - Define TS_ContinueStatement structure
    - Add to inductive TS_Statement
3. `conformance_testing/babel_to_lean.py`
    - Parse AST json “ContinueStatement” → “TS_ContinueStatement”
4. add `%` operation modulo support
4. supporting passing `ControlTargets` for `break/continue` statements