### PR TITLE
Julia/arrowfunc: Arrow function expression

### DIFF
--- a/Strata/Languages/TypeScript/TS_to_Strata.lean
+++ b/Strata/Languages/TypeScript/TS_to_Strata.lean
@@ -207,6 +207,9 @@ partial def translate_expr (e: TS_Expression) : Heap.HExpr :=
     -- just return a heap lambda placeholder
     Heap.HExpr.lambda (.fvar funcName none)
 
+  | .TS_ArrowFunctionExpression e =>
+    Heap.HExpr.lambda (.fvar s!"__arrow_func_{e.start_loc}_{e.end_loc}" none)
+
   | _ => panic! s!"Unimplemented expression: {repr e}"
 
 partial def translate_statement_core
@@ -280,6 +283,26 @@ partial def translate_statement_core
             }
             let newCtx := ctx.addFunction strataFunc
             dbg_trace s!"[DEBUG] Added function '{funcName}' to context"
+            -- Initialize variable to the function reference
+            let ty := get_var_type d.id.typeAnnotation d.init
+            let funcRef := Heap.HExpr.lambda (.fvar funcName none)
+            (newCtx, [.cmd (.init d.id.name ty funcRef)])
+          | .TS_ArrowFunctionExpression funcExpr =>
+            -- Handle arrow function assignment: let x = (args) => { ... }
+            let funcName := d.id.name
+            let funcBody := match funcExpr.body with
+              | .TS_BlockStatement blockStmt =>
+                (blockStmt.body.toList.map (fun stmt => translate_statement_core stmt ctx ct |>.snd)).flatten
+              | _ => panic! s!"Expected block statement as function body, got: {repr funcExpr.body}"
+            dbg_trace s!"[DEBUG] Translating TypeScript arrow function assignment: {d.id.name} = (args) => function(...)"
+            let strataFunc : CallHeapStrataFunction := {
+              name := funcName,
+              params := funcExpr.params.toList.map (·.name),
+              body := funcBody,
+              returnType := none  -- We'll infer this later if needed
+            }
+            let newCtx := ctx.addFunction strataFunc
+            dbg_trace s!"[DEBUG] Added arrow function '{funcName}' to context"
             -- Initialize variable to the function reference
             let ty := get_var_type d.id.typeAnnotation d.init
             let funcRef := Heap.HExpr.lambda (.fvar funcName none)

--- a/Strata/Languages/TypeScript/js_ast.lean
+++ b/Strata/Languages/TypeScript/js_ast.lean
@@ -153,6 +153,15 @@ mutual
     arguments : Array TS_Expression
   deriving Repr, Lean.FromJson, Lean.ToJson
 
+  structure TS_FunctionExpression extends BaseNode where
+    -- id : TS_Identifier
+    -- expression : Bool
+    -- generator : Bool
+    -- async : Bool
+    params : Array TS_Identifier
+    body: TS_Statement
+  deriving Repr, Lean.FromJson, Lean.ToJson
+
   inductive TS_Expression where
     | TS_BinaryExpression : TS_BinaryExpression → TS_Expression
     | TS_ConditionalExpression : TS_ConditionalExpression → TS_Expression
@@ -168,31 +177,32 @@ mutual
     -- | TS_ArrayExpression: TS_ArrayExpression → TS_Expression
     | TS_MemberExpression: TS_MemberExpression → TS_Expression
     | TS_CallExpression: TS_CallExpression → TS_Expression
+    | TS_FunctionExpression: TS_FunctionExpression → TS_Expression
   deriving Repr, Lean.FromJson, Lean.ToJson
-end
 
-structure TS_VariableDeclarator extends BaseNode where
-  id : TS_Identifier
-  init: TS_Expression
-deriving Repr, Lean.FromJson, Lean.ToJson
 
-structure TS_VariableDeclaration extends BaseNode where
-  declarations : Array TS_VariableDeclarator := #[]
-  kind : Option String
-deriving Repr, Lean.FromJson, Lean.ToJson
+  structure TS_VariableDeclarator extends BaseNode where
+    id : TS_Identifier
+    init: TS_Expression
+  deriving Repr, Lean.FromJson, Lean.ToJson
 
-structure TS_EmptyStatement extends BaseNode where
-deriving Repr, Lean.FromJson, Lean.ToJson
+  structure TS_VariableDeclaration extends BaseNode where
+    declarations : Array TS_VariableDeclarator := #[]
+    kind : Option String
+  deriving Repr, Lean.FromJson, Lean.ToJson
 
-structure TS_ExpressionStatement extends BaseNode where
-  expression : TS_Expression
-deriving Repr, Lean.FromJson, Lean.ToJson
+  structure TS_EmptyStatement extends BaseNode where
+  deriving Repr, Lean.FromJson, Lean.ToJson
 
-structure TS_ThrowStatement extends BaseNode where
-  argument: TS_Expression
-deriving Repr, Lean.FromJson, Lean.ToJson
+  structure TS_ExpressionStatement extends BaseNode where
+    expression : TS_Expression
+  deriving Repr, Lean.FromJson, Lean.ToJson
 
-mutual
+  structure TS_ThrowStatement extends BaseNode where
+    argument: TS_Expression
+  deriving Repr, Lean.FromJson, Lean.ToJson
+
+
   structure TS_BlockStatement extends BaseNode where
     body : Array TS_Statement
     directives : Array String := #[]

--- a/Strata/Languages/TypeScript/js_ast.lean
+++ b/Strata/Languages/TypeScript/js_ast.lean
@@ -162,6 +162,11 @@ mutual
     body: TS_Statement
   deriving Repr, Lean.FromJson, Lean.ToJson
 
+  structure TS_ArrowFunctionExpression extends BaseNode where
+    params : Array TS_Identifier
+    body: TS_Statement
+  deriving Repr, Lean.FromJson, Lean.ToJson
+
   inductive TS_Expression where
     | TS_BinaryExpression : TS_BinaryExpression → TS_Expression
     | TS_ConditionalExpression : TS_ConditionalExpression → TS_Expression
@@ -178,6 +183,7 @@ mutual
     | TS_MemberExpression: TS_MemberExpression → TS_Expression
     | TS_CallExpression: TS_CallExpression → TS_Expression
     | TS_FunctionExpression: TS_FunctionExpression → TS_Expression
+    | TS_ArrowFunctionExpression: TS_ArrowFunctionExpression → TS_Expression
   deriving Repr, Lean.FromJson, Lean.ToJson
 
 

--- a/StrataTest/Languages/TypeScript/test_arrow_func.ts
+++ b/StrataTest/Languages/TypeScript/test_arrow_func.ts
@@ -1,0 +1,7 @@
+// Example: Arrow function that adds two numbers
+const add = (x: number, y: number): number => {
+    return x + y;
+};
+
+// Usage
+let result = add(3, 5); // Output: 8

--- a/StrataTest/Languages/TypeScript/test_function_expr.ts
+++ b/StrataTest/Languages/TypeScript/test_function_expr.ts
@@ -1,0 +1,8 @@
+// Test function expression
+let f = function() {
+    let x: number = 1;
+    let y: number = 2;
+    return x + y;
+};
+
+let result: number = f();

--- a/conformance_testing/babel_to_lean.py
+++ b/conformance_testing/babel_to_lean.py
@@ -123,6 +123,14 @@ def parse_function_expression(j):
     add_missing_node_info(j, target_j)
     return target_j
 
+def parse_arrow_function_expression(j):
+    target_j = {
+        'params': [parse_identifier(ji) for ji in j['params']],
+        'body': parse_statement(j['body'])
+    }
+    add_missing_node_info(j, target_j)
+    return target_j
+
 def parse_expression(j):
     match j['type']:
         case "Identifier":
@@ -153,7 +161,8 @@ def parse_expression(j):
             return {"TS_MemberExpression": parse_member_expression(j)}
 
         # case "ThisExpression":
-        # case "ArrowFunctionExpression":
+        case "ArrowFunctionExpression":
+            return {"TS_ArrowFunctionExpression": parse_function_expression(j)}
         # case "YieldExpression":
         # case "AwaitExpression":
         # case "ArrayExpression":

--- a/conformance_testing/babel_to_lean.py
+++ b/conformance_testing/babel_to_lean.py
@@ -115,6 +115,14 @@ def parse_member_expression(j):
     add_missing_node_info(j, target_j)
     return target_j
 
+def parse_function_expression(j):
+    target_j = {
+        'params': [parse_identifier(ji) for ji in j['params']],
+        'body': parse_statement(j['body'])
+    }
+    add_missing_node_info(j, target_j)
+    return target_j
+
 def parse_expression(j):
     match j['type']:
         case "Identifier":
@@ -151,7 +159,8 @@ def parse_expression(j):
         # case "ArrayExpression":
         # case "RecordExpression":
         # case "TupleExpression":
-        # case "FunctionExpression":
+        case "FunctionExpression":
+            return {"TS_FunctionExpression": parse_function_expression(j)}
         # case "UnaryExpression":
         # case "UpdateExpression":
         # case "BindExpression":


### PR DESCRIPTION
1. `TS_to_Strata.lean`

- Implement translation logic for TS_ArrowFunctionExpression in variable declarations and assignments.
- Register arrow function expressions in the translation context under their bound names.

2. `js_ast.lean`

- Define the TS_ArrowFunctionExpression structure.
- Extend the TS_Expression inductive type to include TS_ArrowFunctionExpression.

3. `conformance_testing/babel_to_lean.py`

- Parse Babel "ArrowFunctionExpression" nodes.
- Map them to Lean’s TS_ArrowFunctionExpression structure for conformance testing.
